### PR TITLE
Reduce the maximum queue size by half

### DIFF
--- a/com/uber/kafkaSpraynozzle/KafkaReader.java
+++ b/com/uber/kafkaSpraynozzle/KafkaReader.java
@@ -36,7 +36,7 @@ public class KafkaReader implements Runnable {
             if(pushCount == 100) {
                 pushCount = 0;
                 int queueSize = queue.size();
-                if(queueSize > 1000) {
+                if(queueSize > 500) {
                     this.logQueue.add("clogged");
                     while(queueSize > 100) {
                         try {


### PR DESCRIPTION
From a documented downstream outage, the current queue size is too large and if it is *actually* completely used, will consume all memory on a server and dig into swap.

cc @UberEric @depombo