### PR TITLE
Consume from multiple topics simultaneously

### DIFF
--- a/com/uber/kafkaSpraynozzle/KafkaSpraynozzle.java
+++ b/com/uber/kafkaSpraynozzle/KafkaSpraynozzle.java
@@ -96,7 +96,7 @@ class KafkaSpraynozzle {
             List<KafkaStream<Message>> stream = topicMessageStreams.get(topics[i]);
             streams.add(stream);
         }
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount+(partitionCount*topics.length)+1);
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount + (partitionCount * topics.length) + 1);
 
         // Http Connection Pooling stuff
         final PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();


### PR DESCRIPTION
cc @chris-catignani @chonguber @depombo

Since the partitioning story in kafka 0.7 is pretty bad, some services are artificially sharding a single topic by making multiple topic names and hashing messages to be distributed across these topics.

This change allows spraynozzle to deal with them. It can't handle multiple zookeeper clusters handling the offsets for these topics. That can come later if need be, but considering this change enough of a hack as it is.