### PR TITLE
Partition the ConnectionPool for HTTP requests now that we're doing our own load balancing

### DIFF
--- a/src/main/java/com/uber/kafkaSpraynozzle/KafkaSpraynozzle.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/KafkaSpraynozzle.java
@@ -109,7 +109,7 @@ class KafkaSpraynozzle {
         // Http Connection Pooling stuff
         final PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
         cm.setMaxTotal(threadCount);
-        cm.setDefaultMaxPerRoute(threadCount);
+        cm.setDefaultMaxPerRoute(threadCount / topics.size());
 
         // Message-passing queues within the spraynozzle
         final ConcurrentLinkedQueue<ByteArrayEntity> queue = new ConcurrentLinkedQueue<ByteArrayEntity>();


### PR DESCRIPTION
This is the exact same fix we applied to other Java code.

cc @isaacbrodsky @econti