### PR TITLE
Divide the pool by the number of URLs, not by the number of topics

### DIFF
--- a/src/main/java/com/uber/kafkaSpraynozzle/KafkaSpraynozzle.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/KafkaSpraynozzle.java
@@ -109,7 +109,7 @@ class KafkaSpraynozzle {
         // Http Connection Pooling stuff
         final PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
         cm.setMaxTotal(threadCount);
-        cm.setDefaultMaxPerRoute(threadCount / topics.length);
+        cm.setDefaultMaxPerRoute(threadCount / urls.size());
 
         // Message-passing queues within the spraynozzle
         final ConcurrentLinkedQueue<ByteArrayEntity> queue = new ConcurrentLinkedQueue<ByteArrayEntity>();


### PR DESCRIPTION
Made a mistake, used the wrong variable. Should divide the ConnectionManager by the number of URLs, not by the number of topics.

cc @econti @isaacbrodsky