### PR TITLE
Add benchmark app and improve KafkaPoster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>3.8.1</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -92,7 +92,12 @@
             <artifactId>metrics-jvm</artifactId>
             <version>${io.dropwizard.metrics.version}</version>
         </dependency>
-</dependencies>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>1.57</version>
+        </dependency>
+    </dependencies>
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/com/uber/kafkaSpraynozzle/KafkaArgs.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/KafkaArgs.java
@@ -23,6 +23,6 @@ public interface KafkaArgs {
     @Option(longName="connectionTimeout", defaultToNull=true, description="The connection timeout in milliseconds for posting (default: none)") Integer getConnectionTimeout();
     @Option(longName="socketTimeout", shortName="t", defaultToNull=true, description="The socket timeout in milliseconds for posting (default: none)") Integer getSocketTimeout();
     @Option(longName="help", shortName="h", helpRequest=true, description="Display this Help message") boolean getHelp();
-    @Option(shortName="i", defaultValue = "20", description="Number of messages to pack as a batch before POST to endpoint") int getBatchSize();
+    @Option(shortName="i", defaultValue = "1", description="Number of messages to pack as a batch before POST to endpoint") int getBatchSize();
     @Option(shortName="e", description="Enable Least-Response-Time load balancing when posting") boolean getEnableBalancing();
 }

--- a/src/main/java/com/uber/kafkaSpraynozzle/KafkaArgs.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/KafkaArgs.java
@@ -24,4 +24,5 @@ public interface KafkaArgs {
     @Option(longName="socketTimeout", shortName="t", defaultToNull=true, description="The socket timeout in milliseconds for posting (default: none)") Integer getSocketTimeout();
     @Option(longName="help", shortName="h", helpRequest=true, description="Display this Help message") boolean getHelp();
     @Option(shortName="i", defaultValue = "20", description="Number of messages to pack as a batch before POST to endpoint") int getBatchSize();
+    @Option(shortName="e", defaultToNull=true, description="Enable Least-Response-Time load balancing when posting") String getEnableBalancing();
 }

--- a/src/main/java/com/uber/kafkaSpraynozzle/KafkaArgs.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/KafkaArgs.java
@@ -24,5 +24,5 @@ public interface KafkaArgs {
     @Option(longName="socketTimeout", shortName="t", defaultToNull=true, description="The socket timeout in milliseconds for posting (default: none)") Integer getSocketTimeout();
     @Option(longName="help", shortName="h", helpRequest=true, description="Display this Help message") boolean getHelp();
     @Option(shortName="i", defaultValue = "20", description="Number of messages to pack as a batch before POST to endpoint") int getBatchSize();
-    @Option(shortName="e", defaultToNull=true, description="Enable Least-Response-Time load balancing when posting") String getEnableBalancing();
+    @Option(shortName="e", description="Enable Least-Response-Time load balancing when posting") boolean getEnableBalancing();
 }

--- a/src/main/java/com/uber/kafkaSpraynozzle/KafkaArgs.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/KafkaArgs.java
@@ -23,4 +23,5 @@ public interface KafkaArgs {
     @Option(longName="connectionTimeout", defaultToNull=true, description="The connection timeout in milliseconds for posting (default: none)") Integer getConnectionTimeout();
     @Option(longName="socketTimeout", shortName="t", defaultToNull=true, description="The socket timeout in milliseconds for posting (default: none)") Integer getSocketTimeout();
     @Option(longName="help", shortName="h", helpRequest=true, description="Display this Help message") boolean getHelp();
+    @Option(shortName="i", defaultValue = "20", description="Number of messages to pack as a batch before POST to endpoint") int getBatchSize();
 }

--- a/src/main/java/com/uber/kafkaSpraynozzle/KafkaPoster.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/KafkaPoster.java
@@ -1,5 +1,7 @@
 package com.uber.kafkaSpraynozzle;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -8,6 +10,7 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import org.apache.http.client.config.RequestConfig;
+import kafka.common.InvalidMessageSizeException;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -17,21 +20,38 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.util.EntityUtils;
 
 public class KafkaPoster implements Runnable {
-    private static int currentUrl = 0;
-
     private MetricRegistry metricRegistry;
-    private ConcurrentLinkedQueue<ByteArrayEntity> queue;
-    private PoolingHttpClientConnectionManager cm;
-    private List<String> urls;
-    private KafkaFilter messageFilter;
+    ConcurrentLinkedQueue<ByteArrayEntity> queue;
+    PoolingHttpClientConnectionManager cm;
+    List<String> urls;
+    static int currentUrl = 0;
+    static final int responseDecayingHalflife = 5;
+    KafkaFilter messageFilter;
     private RequestConfig requestConfig;
+    private boolean roundRobin = false;
+    private int batchSize = 20;
+    private int batchMaxBytes = 128*1024;
+    private boolean debuggingOutput = false;
+    private Timer postTime = new Timer();
+    private Counter postCount = new Counter();
+    private Counter postSuccess = new Counter();
+    private Counter postFailure = new Counter();
+    private Counter filteredCount = new Counter();
 
-    private Timer postTime;
-    private Counter postCount;
-    private Counter postSuccess;
-    private Counter postFailure;
-    private Counter filteredCount;
-
+    public KafkaPoster(
+            MetricRegistry metricRegistry,
+            ConcurrentLinkedQueue<ByteArrayEntity> queue,
+            PoolingHttpClientConnectionManager cm,
+            List<String> urls,
+            KafkaFilter messageFilter,
+            Integer socketTimeout,
+            Integer connectionTimeout
+            ){
+        this(metricRegistry,
+                queue, cm, urls, messageFilter,
+                socketTimeout, connectionTimeout,
+                20, false, false );
+    }
     public KafkaPoster(
         MetricRegistry metricRegistry,
         ConcurrentLinkedQueue<ByteArrayEntity> queue,
@@ -39,8 +59,10 @@ public class KafkaPoster implements Runnable {
         List<String> urls,
         KafkaFilter messageFilter,
         Integer socketTimeout,
-        Integer connectionTimeout
-    ) {
+        Integer connectionTimeout,
+        int batchSize,
+        boolean roundRobinPost,
+        boolean debuggingOutput) {
         this.metricRegistry = metricRegistry;
         this.queue = queue;
         this.cm = cm;
@@ -55,54 +77,78 @@ public class KafkaPoster implements Runnable {
         }
         this.requestConfig = builder.build();
 
-        this.postTime = metricRegistry.timer("post_time");
-        this.postCount = metricRegistry.counter("post_count");
-        this.postSuccess = metricRegistry.counter("post_success");
-        this.postFailure = metricRegistry.counter("post_failure");
-        this.filteredCount = metricRegistry.counter("filtered_count");
+        if (metricRegistry != null) {
+            this.postTime = metricRegistry.timer("post_time");
+            this.postCount = metricRegistry.counter("post_count");
+            this.postSuccess = metricRegistry.counter("post_success");
+            this.postFailure = metricRegistry.counter("post_failure");
+            this.filteredCount = metricRegistry.counter("filtered_count");
+        }
+        this.batchSize = batchSize;
+        this.roundRobin = roundRobinPost;
+        this.debuggingOutput = debuggingOutput;
     }
 
+    private int leastResponseIdx(int[] responseTime) {
+        int leastIdx = 0;
+        for (int i = 1; i < responseTime.length; ++i){
+            if (responseTime[i] < responseTime[leastIdx]){
+                leastIdx = i;
+            }
+        }
+        return leastIdx;
+    }
+
+    private int getBatchDataSize(List<ByteArrayEntity> batch){
+        int totalSize = 0;
+        for (int i = 0; i < batch.size(); ++i){
+            totalSize += (int)batch.get(i).getContentLength();
+        }
+        return totalSize;
+    }
+
+    private CloseableHttpClient client = null;
+    private long threadId = 0L;
+    private long lastReconnect = 0L;
+    private int[] responseTime = null;
+    private long[] responseTimestamp = null;
     public void run() {
-        long threadId = Thread.currentThread().getId();
+        threadId = Thread.currentThread().getId();
         System.out.println("Starting poster thread " + threadId);
-        CloseableHttpClient client = HttpClientBuilder.create().setConnectionManager(cm).build();
-        long lastReconnect = new Date().getTime();
+        client = HttpClientBuilder.create().setConnectionManager(cm).build();
+        lastReconnect = new Date().getTime();
+        responseTime = new int[urls.size()];
+        responseTimestamp = new long[urls.size()];
+
+        List<ByteArrayEntity> batch = new ArrayList<ByteArrayEntity>(batchSize + 1);
+
+        long totalPostingTimeMs = 0L;
+        long totalPostingCount = 0L;
+        long lastReportingTime = new Date().getTime();
         while(true) {
             ByteArrayEntity jsonEntity = queue.poll();
             if(jsonEntity != null) {
                 jsonEntity = messageFilter.filter(jsonEntity);
                 if (jsonEntity != null) {
+                    batch.add(jsonEntity);
 
-                    try (Timer.Context ctx = postTime.time()) {
-                        postCount.inc();
-                        HttpPost post = new HttpPost(urls.get(currentUrl));
-                        currentUrl = (currentUrl + 1) % urls.size();
-                        post.setHeader("User-Agent", "KafkaSpraynozzle-0.0.1");
-                        post.setEntity(jsonEntity);
-                        post.setConfig(requestConfig);
-                        CloseableHttpResponse response = client.execute(post);
-                        int statusCode = response.getStatusLine().getStatusCode();
-                        if (statusCode >= 200 && statusCode < 300) {
-                            postSuccess.inc();
-                        } else {
-                            postFailure.inc();
+                    if (batch.size() >= batchSize || getBatchDataSize(batch) >= batchMaxBytes) {
+                        long timeBeforePost = new Date().getTime();
+                        if (debuggingOutput && timeBeforePost - lastReportingTime > 5*1000) {
+                            System.out.println(String.format(
+                                    "Posting thread %d, avg posting cost %d ms, total posting called %d",
+                                    threadId, totalPostingTimeMs / totalPostingCount, totalPostingCount));
+                            lastReportingTime = timeBeforePost;
                         }
-                        long currentTime = new Date().getTime();
-                        if(currentTime - lastReconnect > 10000) {
-                            lastReconnect = currentTime;
-                            response.close();
-                        } else {
-                            EntityUtils.consume(response.getEntity());
-                        }
-                    } catch (java.io.IOException e) {
-                        System.out.println("IO issue");
-                        e.printStackTrace();
-                        postFailure.inc();
+                        postBatchEvents(batch);
+                        totalPostingCount += 1;
+                        totalPostingTimeMs += (new Date().getTime() - timeBeforePost);
                     }
                 } else {
                     filteredCount.inc();
                 }
             } else {
+                postBatchEvents(batch);
                 try {
                     Thread.sleep(250);
                 } catch (java.lang.InterruptedException e) {
@@ -111,5 +157,66 @@ public class KafkaPoster implements Runnable {
                 }
             }
         }
+    }
+
+    private boolean postBatchEvents(List<ByteArrayEntity> batch) {
+        int pickedUrlIdx;
+        try (Timer.Context ctx = postTime.time()) {
+            long timeBeforePost = new Date().getTime();
+            postCount.inc();
+            if (roundRobin) {
+                pickedUrlIdx = currentUrl;
+            } else {
+                pickedUrlIdx = leastResponseIdx(responseTime);
+            }
+            HttpPost post = new HttpPost(urls.get(pickedUrlIdx));
+            if (roundRobin) {
+                currentUrl = (currentUrl + 1) % urls.size();
+            }
+            post.setHeader("User-Agent", "KafkaSpraynozzle-0.0.1");
+            try {
+                ByteArrayEntity packedEntities = ListSerializer.toByteArrayEntity(batch);
+                post.setEntity(packedEntities);
+                batch.clear();
+            }catch(InvalidMessageSizeException ex){
+                postFailure.inc();
+                batch.clear();
+                return false;
+            }
+            CloseableHttpResponse response = client.execute(post);
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode >= 200 && statusCode < 300) {
+                postSuccess.inc();
+            } else {
+                postFailure.inc();
+            }
+            long timeAfterPost = new Date().getTime();
+
+            //// managing the "least response time" decay.
+            //// Every time halflife time has passed, we reduce the "bad record" of response time by half
+            /// so eventually those bad servers with slow response time will get another chance of being tried.
+            /// and we will not keep pounding the same fast server since all record of response time decays.
+            responseTimestamp[pickedUrlIdx] = timeAfterPost;
+            responseTime[pickedUrlIdx] = (int) (timeAfterPost - timeBeforePost) + 5;// penalize by 5 ms
+            for (int i = 0; i < responseTimestamp.length; ++i) {
+                if ((timeAfterPost - responseTimestamp[i]) > responseDecayingHalflife * 1000) {
+                    responseTimestamp[i] = timeAfterPost;
+                    responseTime[i] = responseTime[i] / 2;
+                }
+            }
+            long currentTime = new Date().getTime();
+            if (currentTime - lastReconnect > 10000) {
+                lastReconnect = currentTime;
+                response.close();
+            } else {
+                EntityUtils.consume(response.getEntity());
+            }
+        } catch (IOException e) {
+            System.out.println("IO issue");
+            e.printStackTrace();
+            postFailure.inc();
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/com/uber/kafkaSpraynozzle/KafkaPoster.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/KafkaPoster.java
@@ -167,7 +167,7 @@ public class KafkaPoster implements Runnable {
         final long NANOS_PER_MILLI_SECOND = 1000L * 1000L;
         int pickedUrlIdx;
         try (Timer.Context ctx = postTime.time()) {
-            long timeBeforePost = new Date().getTime();
+            long timeBeforePost = System.nanoTime();
             postCount.inc();
             if (roundRobin) {
                 pickedUrlIdx = currentUrl;

--- a/src/main/java/com/uber/kafkaSpraynozzle/KafkaPoster.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/KafkaPoster.java
@@ -50,7 +50,7 @@ public class KafkaPoster implements Runnable {
         this(metricRegistry,
                 queue, cm, urls, messageFilter,
                 socketTimeout, connectionTimeout,
-                20, false, false );
+                1, false, false );
     }
     public KafkaPoster(
         MetricRegistry metricRegistry,
@@ -83,6 +83,9 @@ public class KafkaPoster implements Runnable {
             this.postSuccess = metricRegistry.counter("post_success");
             this.postFailure = metricRegistry.counter("post_failure");
             this.filteredCount = metricRegistry.counter("filtered_count");
+        }
+        if (batchSize <= 0){
+            batchSize = 1;
         }
         this.batchSize = batchSize;
         this.roundRobin = roundRobinPost;

--- a/src/main/java/com/uber/kafkaSpraynozzle/KafkaSpraynozzle.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/KafkaSpraynozzle.java
@@ -156,7 +156,7 @@ class KafkaSpraynozzle {
         for (int i = 0; i < threadCount; i++) {
             // create new filter for every thread so the filters member variables are not shared
             KafkaFilter messageFilter = getKafkaFilter(filterClass, filterClasspath, filterClassArgs);
-            executor.submit(new KafkaPoster(metricRegistry, queue, cm, urls, messageFilter, soTimeout, connectTimeout));
+            executor.submit(new KafkaPoster(metricRegistry, queue, cm, urls, messageFilter, soTimeout, connectTimeout, 20, false, false));
         }
     }
 

--- a/src/main/java/com/uber/kafkaSpraynozzle/KafkaSpraynozzle.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/KafkaSpraynozzle.java
@@ -158,7 +158,8 @@ class KafkaSpraynozzle {
         for (int i = 0; i < threadCount; i++) {
             // create new filter for every thread so the filters member variables are not shared
             KafkaFilter messageFilter = getKafkaFilter(filterClass, filterClasspath, filterClassArgs);
-            executor.submit(new KafkaPoster(metricRegistry, queue, cm, urls, messageFilter, soTimeout, connectTimeout, 20, forceRoundRobin, false));
+            executor.submit(new KafkaPoster(metricRegistry, queue, cm, urls, messageFilter, soTimeout, connectTimeout,
+                    batchPostingSize, forceRoundRobin, false));
         }
     }
 

--- a/src/main/java/com/uber/kafkaSpraynozzle/KafkaSpraynozzle.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/KafkaSpraynozzle.java
@@ -75,7 +75,7 @@ class KafkaSpraynozzle {
         final Integer soTimeout = spraynozzleArgs.getSocketTimeout();
         final Integer connectTimeout = spraynozzleArgs.getConnectionTimeout();
         final int batchPostingSize = spraynozzleArgs.getBatchSize();
-        final boolean forceRoundRobin = spraynozzleArgs.getEnableBalancing() == null;
+        final boolean forceRoundRobin = !spraynozzleArgs.getEnableBalancing();
         String[] topics = topic.split(",");
         if (topics.length == 1) {
             System.out.println("Listening to " + topic + " topic from " + zk + " and redirecting to " + urls);

--- a/src/main/java/com/uber/kafkaSpraynozzle/KafkaSpraynozzle.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/KafkaSpraynozzle.java
@@ -74,6 +74,8 @@ class KafkaSpraynozzle {
         final String statsClassArgs = spraynozzleArgs.getStatsClassArgs();
         final Integer soTimeout = spraynozzleArgs.getSocketTimeout();
         final Integer connectTimeout = spraynozzleArgs.getConnectionTimeout();
+        final int batchPostingSize = spraynozzleArgs.getBatchSize();
+        final boolean forceRoundRobin = spraynozzleArgs.getEnableBalancing() == null;
         String[] topics = topic.split(",");
         if (topics.length == 1) {
             System.out.println("Listening to " + topic + " topic from " + zk + " and redirecting to " + urls);
@@ -156,7 +158,7 @@ class KafkaSpraynozzle {
         for (int i = 0; i < threadCount; i++) {
             // create new filter for every thread so the filters member variables are not shared
             KafkaFilter messageFilter = getKafkaFilter(filterClass, filterClasspath, filterClassArgs);
-            executor.submit(new KafkaPoster(metricRegistry, queue, cm, urls, messageFilter, soTimeout, connectTimeout, 20, false, false));
+            executor.submit(new KafkaPoster(metricRegistry, queue, cm, urls, messageFilter, soTimeout, connectTimeout, 20, forceRoundRobin, false));
         }
     }
 

--- a/src/main/java/com/uber/kafkaSpraynozzle/ListSerializer.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/ListSerializer.java
@@ -1,0 +1,112 @@
+package com.uber.kafkaSpraynozzle;
+
+import kafka.common.InvalidMessageSizeException;
+import org.apache.http.entity.ByteArrayEntity;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+/**
+ * Created by xdong on 11/17/15.
+ * This serializer just serializes a list of ByteArrayEntities into one single ByteArrayEntities
+ * Later it can be deserialized back.
+ */
+public class ListSerializer {
+
+    private static void writeIntToByteStream(int val, ByteArrayOutputStream stream){
+        byte[] buf = {0,0,0,0};
+        buf[3] = (byte) (val       );
+        buf[2] = (byte) (val >>>  8);
+        buf[1] = (byte) (val >>> 16);
+        buf[0] = (byte) (val >>> 24);
+        stream.write(buf, 0, 4);
+    }
+
+    private static int readIntFromByteStream(ByteArrayInputStream stream) throws IOException{
+        byte[] buf = {0,0,0,0};
+        int actualRead = stream.read(buf, 0, 4);
+        if (actualRead != 4){
+            throw new IOException("Deserialized data corrupted");
+        }
+        return getInt(buf);
+    }
+
+    private static int getInt(byte[] b) {
+        return ((b[3] & 0xFF)      ) +
+                ((b[2] & 0xFF) <<  8) +
+                ((b[1] & 0xFF) << 16) +
+                ((b[0]       ) << 24);
+    }
+
+    /**
+     * Serialize the List\<ByteArrayEntitity\> object into an byte array so it can be posted in one call
+     * The encoding rule is plain simple:
+     *  {totalElements}{length}{byte block of length}{length}{byte block of length}...
+     * @param entities the List objects to serialize
+     * @return the one single byte array, encoded.
+     * @throws InvalidMessageSizeException If the array is too large to fit into one huge memory
+     * @throws IOException if anything is wrong.
+     */
+    public static ByteArrayEntity toByteArrayEntity(List<ByteArrayEntity> entities) throws InvalidMessageSizeException, IOException {
+        long totalLength = 0L;
+        final long largest_block = 1024L*1024L*128L;
+        for (int i = 0; i < entities.size(); ++i){
+            totalLength += entities.get(i).getContentLength();
+        }
+        if (totalLength >= largest_block){ // >=128MB is dangerous
+            throw new InvalidMessageSizeException("The batched messages are too large");
+        }
+        ByteArrayOutputStream serialized = new ByteArrayOutputStream();
+        writeIntToByteStream(entities.size(), serialized);
+        for (int i = 0; i < entities.size(); ++i){
+            writeIntToByteStream((int) entities.get(i).getContentLength(), serialized);
+            entities.get(i).writeTo(serialized);
+        }
+        return new ByteArrayEntity(serialized.toByteArray());
+    }
+
+    /**
+     * Deserialize the byte block back into our List<ByteArrayEntity> object
+     * @param serialized the byte block
+     * @return the deserialized object
+     * @throws InvalidMessageSizeException if the data is corrupted, causing too huge data
+     * @throws IOException if somehow stream read/write fails, or data corrupted
+     */
+    public static List<ByteArrayEntity> toListOfByteArrayEntity(byte[] serialized) throws InvalidMessageSizeException, IOException {
+        ByteArrayInputStream input = new ByteArrayInputStream(serialized);
+        final long largest_block = 1024L*1024L*128L;
+
+        int arraySize = readIntFromByteStream(input);
+        List<ByteArrayEntity> retVal = new ArrayList<ByteArrayEntity>(arraySize);
+        for (int i = 0; i < arraySize; ++i){
+            int objectSize = readIntFromByteStream(input);
+            if (objectSize >= largest_block){ // >=128MB is dangerous
+                throw new InvalidMessageSizeException("The batched messages are too large");
+            }
+            byte[] objectBytes = new byte[objectSize];
+            int actualRead = input.read(objectBytes, 0, objectSize);
+            if (actualRead != objectSize){
+                throw new IOException("Deserialized entity corrupted");
+            }
+            ByteArrayEntity entity = new ByteArrayEntity(objectBytes);
+            retVal.add(entity);
+        }
+        return retVal;
+    }
+
+    /**
+     * Helper class for converting ByteArrayEntity to byte[] array
+     * @param entity The byte array entity
+     * @return The byte array copy
+     */
+    public static byte[] getByteArrayEntityBytes(ByteArrayEntity entity){
+        ByteArrayOutputStream serialized = new ByteArrayOutputStream();
+        try {
+            entity.writeTo(serialized);
+            return serialized.toByteArray();
+        }catch(IOException ex){
+            return new byte[0];
+        }
+    }
+
+}

--- a/src/main/java/com/uber/kafkaSpraynozzle/benchmark/BenchmarkArgs.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/benchmark/BenchmarkArgs.java
@@ -1,0 +1,32 @@
+package com.uber.kafkaSpraynozzle.benchmark;
+
+import com.lexicalscope.jewel.cli.CommandLineInterface;
+import com.lexicalscope.jewel.cli.Option;
+
+/**
+ * Created by xdong on 11/16/15.
+ */
+@CommandLineInterface(application="kafka-spraynozzle-benchmark")
+public interface BenchmarkArgs {
+    @Option(shortName="rt", defaultValue = "4", description="Reader thread count")
+    int getReaderThreads();
+    @Option(shortName="pt", defaultValue = "4", description="Post thread count")
+    int getPostThreads();
+    @Option(shortName="mps", defaultValue = "200000", description="Kafka Message Per Second, Per thread")
+    int getMessagePerPerSecond();
+    @Option(shortName="size", defaultValue = "2240", description="Kafka Message Size, in bytes")
+    int getMessageSize();
+    @Option(shortName="pc", defaultValue = "10", description="Post cost in micro-seconds (1/1000 of milliseconds)")
+    int getPostCost();
+    @Option(shortName="t", defaultValue = "90", description="Test time in seconds")
+    int getTestTime();
+    @Option(shortName="e", defaultValue = "1", description="enable real http test")
+    int getEnableRealHttp();
+    @Option(shortName="n", defaultValue = "4", description="http endpoint count")
+    int getHttpEndpointCount();
+    @Option(shortName="f", defaultValue = "0", description="Force round robin post instead of least-response time")
+    int getForceRoundRobin();
+    @Option(shortName="s", defaultValue = "20", description="How many messages to do in one batch")
+    int getPackingPerPost();
+
+}

--- a/src/main/java/com/uber/kafkaSpraynozzle/benchmark/BenchmarkSpraynozzle.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/benchmark/BenchmarkSpraynozzle.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -130,6 +131,7 @@ public class BenchmarkSpraynozzle {
         }
         abortFlag.set(true);
         executor.shutdown();
+        executor.awaitTermination(300, TimeUnit.SECONDS);
         for (WireMockServer server: servers){
             server.shutdown();
         }

--- a/src/main/java/com/uber/kafkaSpraynozzle/benchmark/BenchmarkSpraynozzle.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/benchmark/BenchmarkSpraynozzle.java
@@ -1,0 +1,111 @@
+package com.uber.kafkaSpraynozzle.benchmark;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.http.*;
+
+import static com.github.tomakehurst.wiremock.http.RequestMethod.POST;
+
+import com.github.tomakehurst.wiremock.matching.RequestPattern;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import com.lexicalscope.jewel.cli.ArgumentValidationException;
+import com.lexicalscope.jewel.cli.CliFactory;
+import com.uber.kafkaSpraynozzle.KafkaNoopFilter;
+import com.uber.kafkaSpraynozzle.KafkaPoster;
+import com.uber.kafkaSpraynozzle.KafkaReader;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Created by xdong on 11/16/15.
+ * The benchmark tries to pump messages into the queue, and then either takes out the queue items directly,
+ * or starts a real local http server to test the KafkaPoster thread.
+ *
+ * By this benchmark, we can get the throughput of enqueue, get the load balancing tested.
+ *
+ */
+public class BenchmarkSpraynozzle {
+
+    public static void main(String[] args) throws Exception {
+        BenchmarkArgs benchmarkArgs;
+        try {
+            benchmarkArgs = CliFactory.parseArguments(BenchmarkArgs.class, args);
+        } catch(ArgumentValidationException e) {
+            System.err.println(e.getMessage());
+            System.err.println(CliFactory.createCli(BenchmarkArgs.class).getHelpMessage());
+            return;
+        }
+
+        System.out.print("\nTesting setting: \n");
+        if (benchmarkArgs.getEnableRealHttp() == 1){
+            System.out.print("Posting to endpoint, with endpoint[0] has 200ms delays.\n");
+        }else{
+            System.out.print("Skipping endpoint write.\n");
+        }
+        if (benchmarkArgs.getForceRoundRobin() == 1){
+            System.out.print("Forcing round-robin.\n");
+        }else{
+            System.out.print("Least-response-time balancing.\n");
+        }
+        System.out.print(String.format("Packing %d items in post.\n", benchmarkArgs.getPackingPerPost()));
+        System.out.println("\n");
+
+        final long NANO_PER_SECOND = 1000L*1000L*1000L;
+
+        ExecutorService executor = Executors.newFixedThreadPool(benchmarkArgs.getReaderThreads() + benchmarkArgs.getPostThreads() + 1);
+        final ConcurrentLinkedQueue<ByteArrayEntity> queue = new ConcurrentLinkedQueue<ByteArrayEntity>();
+        final ConcurrentLinkedQueue<String> logQueue = new ConcurrentLinkedQueue<String>();
+        AtomicBoolean abortFlag = new AtomicBoolean(false);
+        for (int i = 0; i < benchmarkArgs.getReaderThreads(); ++i){
+            KafkaReader reader = new KafkaReader(null, queue, null);
+            KafkaReaderDriver driver = new KafkaReaderDriver(reader, benchmarkArgs.getTestTime() * benchmarkArgs.getMessagePerPerSecond(),
+                    benchmarkArgs.getMessageSize(), benchmarkArgs.getMessagePerPerSecond(), abortFlag);
+            executor.submit(driver);
+        }
+
+
+        if (benchmarkArgs.getEnableRealHttp() == 1){
+            // Http Connection Pooling stuff
+            List<String> urls = new ArrayList<String>(benchmarkArgs.getHttpEndpointCount());
+            for (int i = 0; i < benchmarkArgs.getHttpEndpointCount(); ++i){
+                urls.add("http://localhost:" + (18982 + i) + "/endpoint");
+            }
+            List<WireMockServer> servers = new ArrayList<WireMockServer>(benchmarkArgs.getHttpEndpointCount());
+            for (int i = 0; i < benchmarkArgs.getHttpEndpointCount(); ++i){
+                servers.add(new WireMockServer(18982 + i));
+                servers.get(i).addStubMapping(new StubMapping(new RequestPattern(POST, "/endpoint"), ResponseDefinition.ok()));
+                servers.get(i).start();
+                if (i == 0){ /// introduce imbalanced server response.
+                    servers.get(0).addRequestProcessingDelay(200);
+                }
+            }
+            final PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
+            cm.setMaxTotal(benchmarkArgs.getPostThreads());
+            cm.setDefaultMaxPerRoute(benchmarkArgs.getPostThreads());
+
+            for (int i = 0; i < benchmarkArgs.getPostThreads(); ++i) {
+                KafkaPoster poster = new KafkaPoster(null, queue, cm, urls, new KafkaNoopFilter(),
+                        2000, 1000, 20, benchmarkArgs.getForceRoundRobin() == 1, true);
+                executor.submit(poster);
+            }
+
+        }else {
+            for (int i = 0; i < benchmarkArgs.getPostThreads(); ++i) {
+                KafkaPosterSimulator poster = new KafkaPosterSimulator(benchmarkArgs.getPostCost(), queue, abortFlag);
+                executor.submit(poster);
+            }
+        }
+        long startNanoTime = System.nanoTime();
+        while (System.nanoTime() - startNanoTime < (benchmarkArgs.getTestTime() + 20)* NANO_PER_SECOND ){
+            Thread.sleep(1000);
+        }
+        abortFlag.set(true);
+        executor.shutdown();
+    }
+}

--- a/src/main/java/com/uber/kafkaSpraynozzle/benchmark/KafkaPosterSimulator.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/benchmark/KafkaPosterSimulator.java
@@ -1,0 +1,64 @@
+package com.uber.kafkaSpraynozzle.benchmark;
+
+import org.apache.http.entity.ByteArrayEntity;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * This simulator is just taking out queue items, and throws them away.
+ * If needed it can simulate the delay in post.
+ * Created by xdong on 11/16/15.
+ */
+public class KafkaPosterSimulator implements Runnable {
+    public KafkaPosterSimulator(int postCostInMicroseconds, ConcurrentLinkedQueue<ByteArrayEntity> queue,
+                                AtomicBoolean abortFlag){
+        this.postCostInMicroseconds = postCostInMicroseconds;
+        this.queue = queue;
+        this.abort = abortFlag;
+    }
+    private AtomicBoolean abort = new AtomicBoolean(false);
+    private long postCostInMicroseconds = 1L;
+    private ConcurrentLinkedQueue<ByteArrayEntity> queue;
+    private final long NANO_PER_SECOND = 1000L*1000L*1000L;
+    private final long PRINT_INTERVAL_IN_SEC = 5; /// every 5 seconds print one stats
+
+    private static void sleepNanoSeconds(long nanoSecondsSleep){
+        long start = System.nanoTime();
+        long end;
+        do{
+            end = System.nanoTime();
+            Thread.yield();
+        }while(start + nanoSecondsSleep >= end);
+    }
+
+    public void run() {
+        long startNanoTime = System.nanoTime();
+        long simulatedPostCount = 0L;
+        long sleepInNano = 1000;
+        long lastReportNanoTime = startNanoTime;
+        long threadId = Thread.currentThread().getId();
+
+        while(!abort.get()){
+            ByteArrayEntity entity = queue.poll();
+            long currentNanoTime = System.nanoTime();
+            long overallNanoTime = (currentNanoTime - startNanoTime + 1);
+            if (entity != null) {
+                simulatedPostCount += 1;
+                long simulatedCostInMilli = overallNanoTime / 1000 / simulatedPostCount;
+                while (simulatedCostInMilli < postCostInMicroseconds){
+                    sleepNanoSeconds(sleepInNano);
+                    currentNanoTime = System.nanoTime();
+                    overallNanoTime = (currentNanoTime - startNanoTime + 1);
+                    simulatedCostInMilli = overallNanoTime / 1000 / simulatedPostCount;
+                }
+            }
+            if (currentNanoTime - lastReportNanoTime > PRINT_INTERVAL_IN_SEC * NANO_PER_SECOND){
+                lastReportNanoTime = currentNanoTime;
+                System.out.println(String.format("Post thread %d: Posting at %d message/sec.", threadId,
+                        simulatedPostCount * NANO_PER_SECOND/overallNanoTime));
+
+            }
+        }
+    }
+}

--- a/src/main/java/com/uber/kafkaSpraynozzle/benchmark/KafkaReaderDriver.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/benchmark/KafkaReaderDriver.java
@@ -1,0 +1,73 @@
+package com.uber.kafkaSpraynozzle.benchmark;
+
+import com.uber.kafkaSpraynozzle.KafkaReader;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * This class takes in one KafkaReader, and test the code path where it enqueues
+ * It is driven by a thread.
+ */
+class KafkaReaderDriver implements Runnable {
+    public KafkaReaderDriver(KafkaReader readerToTest, long packageCount,
+                             int packageSize, int packagePerSecond, AtomicBoolean abortFlag){
+        reader = readerToTest;
+        sleepNanoInterval = 1000000000L/packagePerSecond;
+        this.packageCount = packageCount;
+        this.packageSize = packageSize;
+        this.packagePerSecond = packagePerSecond;
+        abort = abortFlag;
+    }
+    private KafkaReader reader;
+    private long sleepNanoInterval = 10000; // 10 microseconds, 0.01 milli
+    private long packageCount = 1000000;
+    private int packageSize = 2000; // 2KB
+    private int packagePerSecond = 1000;
+    private final long NANO_PER_SECOND = 1000L*1000L*1000L;
+    private final long PRINT_INTERVAL_IN_SEC = 5; /// every 5 seconds print one stats
+    private AtomicBoolean abort = new AtomicBoolean(false);
+
+    private static void sleepNanoSeconds(long nanoSecondsSleep){
+        long start = System.nanoTime();
+        long end;
+        do{
+            end = System.nanoTime();
+            Thread.yield();
+        }while(start + nanoSecondsSleep >= end);
+    }
+
+    public void run() {
+
+        long threadId = Thread.currentThread().getId();
+        System.out.println("Starting reader thread " + threadId);
+        int pushCount = 0;
+        byte[] bytes = new byte[packageSize];
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        long overallStartTime = System.nanoTime();
+        long lastReportTime = overallStartTime;
+        long totalSleepingNanoSeconds = 0L;
+        for(long i = 0L; i < packageCount && !abort.get(); ++i) {
+            ByteBuffer message = buffer;
+            Integer messageLen = buffer.array().length;
+            pushCount = reader.enqueueData(pushCount, messageLen, message);
+
+            long currentEndTime = System.nanoTime();
+            long totalElapsedTime = (currentEndTime - overallStartTime + 1); /// avoid division by zero
+            long currentMessagePerSecond = (i + 1) * NANO_PER_SECOND / totalElapsedTime ;
+            /// target our packagePerSecond goal here
+            if ( currentMessagePerSecond > packagePerSecond ) {
+                sleepNanoSeconds(sleepNanoInterval);
+                totalSleepingNanoSeconds += sleepNanoInterval;
+            }
+
+            if (currentEndTime - lastReportTime > PRINT_INTERVAL_IN_SEC * NANO_PER_SECOND){
+                System.out.println(String.format("Reader Thread %d: Sustained %d message/sec, %d KiB/sec. %d percent idle", threadId,
+                        currentMessagePerSecond, currentMessagePerSecond * packageSize / 1000,
+                        totalSleepingNanoSeconds * 100 / totalElapsedTime ));
+                lastReportTime = currentEndTime;
+            }
+        }
+    }
+
+}

--- a/src/test/java/com/uber/kafkaSpraynozzle/ListSerializerTest.java
+++ b/src/test/java/com/uber/kafkaSpraynozzle/ListSerializerTest.java
@@ -1,0 +1,101 @@
+
+package com.uber.kafkaSpraynozzle;
+
+import kafka.common.InvalidMessageSizeException;
+import org.apache.http.entity.ByteArrayEntity;
+import org.junit.Test;
+
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by xdong on 11/17/15.
+ */
+public class ListSerializerTest {
+
+    @Test
+    public void SimpleCaseShouldWork(){
+        int arrayLength = 10;
+        List<ByteArrayEntity> entities = new ArrayList<ByteArrayEntity>(arrayLength);
+        for (int i = 0; i < arrayLength; ++i){
+            int elementLength = i * 10;
+            ByteArrayOutputStream helper = new ByteArrayOutputStream();
+            for (int j = 0; j < elementLength; ++j){
+                helper.write(i * 1000 + j);
+            }
+            ByteArrayEntity entity = new ByteArrayEntity(helper.toByteArray());
+            entities.add(entity);
+        }
+        ByteArrayEntity serialized = null;
+        try {
+            serialized = ListSerializer.toByteArrayEntity(entities);
+        }catch(InvalidMessageSizeException ex){
+            assert("corrupted message size".equals(ex.getMessage()));
+        }catch(IOException ex){
+            assert("IO exception during exception".equals(ex.getMessage()));
+        }
+        assert(serialized != null && serialized.getContentLength() > 100L);
+
+        byte[] payload = ListSerializer.getByteArrayEntityBytes(serialized);
+
+        List<ByteArrayEntity> deserialized = null;
+        try {
+            deserialized = ListSerializer.toListOfByteArrayEntity(payload);
+        }catch(IOException ex){
+            assert("IO exception during exception".equals(ex.getMessage()));
+        }
+        assert(deserialized != null && deserialized.size() == entities.size());
+        for (int i = 0; i < entities.size(); ++i){
+            assert(entities.get(i).getContentLength() == deserialized.get(i).getContentLength());
+            byte[] originalBytes = ListSerializer.getByteArrayEntityBytes(entities.get(i));
+            byte[] pipedBytes = ListSerializer.getByteArrayEntityBytes(deserialized.get(i));
+            assert(originalBytes.length == pipedBytes.length);
+            for (int j = 0; j < originalBytes.length; ++j){
+                assert(originalBytes[j] == pipedBytes[j]);
+            }
+        }
+    }
+    @Test
+    public void ExceptionForCorruptedData(){
+        int arrayLength = 10;
+        List<ByteArrayEntity> entities = new ArrayList<ByteArrayEntity>(arrayLength);
+        for (int i = 0; i < arrayLength; ++i){
+            int elementLength = i * 10;
+            ByteArrayOutputStream helper = new ByteArrayOutputStream();
+            for (int j = 0; j < elementLength; ++j){
+                helper.write(i * 1000 + j);
+            }
+            ByteArrayEntity entity = new ByteArrayEntity(helper.toByteArray());
+            entities.add(entity);
+        }
+        ByteArrayEntity serialized = null;
+        try {
+            serialized = ListSerializer.toByteArrayEntity(entities);
+        }catch(InvalidMessageSizeException ex){
+            assert("corrupted message size".equals(ex.getMessage()));
+        }catch(IOException ex){
+            assert("IO exception during exception".equals(ex.getMessage()));
+        }
+        assert(serialized != null && serialized.getContentLength() > 100L);
+
+        byte[] payload = ListSerializer.getByteArrayEntityBytes(serialized);
+        for (int i = 0; i < payload.length; ++i){
+            payload[i] += i;
+        }
+        boolean exceptionThrown = false;
+        List<ByteArrayEntity> deserialized = null;
+        try {
+            deserialized = ListSerializer.toListOfByteArrayEntity(payload);
+        }catch(IOException ex){
+            exceptionThrown = true;
+
+        }catch(InvalidMessageSizeException ex){
+            exceptionThrown = true;
+        }
+        assert(exceptionThrown);
+        assert(deserialized == null);
+    }
+}


### PR DESCRIPTION
##Three changes
1. Created a benchmark application to simulate the enqueue/dequeue threads, with the aim of identifying bottleneck.
2. Update the KafkaPoster thread with "Least-Response-Time" balance strategy when choosing endpoints to post, instead of the round-robin strategy. This will help a lot in load balancing;
3. Update the KafkaPoster to pack messages in batches instead of "one-post-per-message". This will further help performance.

##The tests result collected by the benchmarking app (in MacBook Pro i7)
a. The throughput of queue is around 1Mil Messages/Second all threads combined, if posting is fast enough
b. If Posting through endpoint is around 1~10 ms per post, the sustained speed is only around 1k~10k messages/second
c. If we introduce one slow endpoint with 200ms response time, it is as if all endpoints are 200ms response time
d. The situation of one slowed endpoint can be fixed and observed by "Least-Response-Time" balancing strategy

Overall the improvement in the KafkaPoster side is huge. It is hard to get a number because it depends on how one lagging server can be. Say we have 200ms, 19 ms, 50ms, 10ms response time, we can have 5x or 10x improvement simply by "least-response-time" balancing.
