### PR TITLE
fix the bad response penalty error

### DIFF
--- a/src/main/java/com/uber/kafkaSpraynozzle/KafkaPoster.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/KafkaPoster.java
@@ -165,7 +165,7 @@ public class KafkaPoster implements Runnable {
     private boolean postBatchEvents(List<ByteArrayEntity> batch) {
         final long NANOS_PER_SECOND = 1000L * 1000L * 1000L;
         final long NANOS_PER_MILLI_SECOND = 1000L * 1000L;
-        int pickedUrlIdx;
+        int pickedUrlIdx = currentUrl;
         try (Timer.Context ctx = postTime.time()) {
             long timeBeforePost = System.nanoTime();
             postCount.inc();
@@ -236,6 +236,9 @@ public class KafkaPoster implements Runnable {
             System.out.println("IO issue");
             e.printStackTrace();
             postFailure.inc();
+            responseTimestamp[pickedUrlIdx] = System.nanoTime();
+            responseTime[pickedUrlIdx] = 5 * NANOS_PER_SECOND;
+
             return false;
         }
         return true;

--- a/src/main/java/com/uber/kafkaSpraynozzle/KafkaPoster.java
+++ b/src/main/java/com/uber/kafkaSpraynozzle/KafkaPoster.java
@@ -214,12 +214,8 @@ public class KafkaPoster implements Runnable {
                 responseTime[pickedUrlIdx] = (timeAfterPost - timeBeforePost) + 2 * NANOS_PER_MILLI_SECOND;// penalize by 2 ms so the same won't be used again and again.
             } else {
                 postFailure.inc();
-                //// managing the "least response time" decay.
-                //// Every time halflife time has passed, we reduce the "bad record" of response time by half
-                /// so eventually those bad servers with slow response time will get another chance of being tried.
-                /// and we will not keep pounding the same fast server since all record of response time decays.
                 responseTimestamp[pickedUrlIdx] = timeAfterPost;
-                responseTime[pickedUrlIdx] = (timeAfterPost - timeBeforePost) + 5 * NANOS_PER_SECOND;// penalize by 2 ms so the same won't be used again and again.
+                responseTime[pickedUrlIdx] = (timeAfterPost - timeBeforePost) + 5 * NANOS_PER_SECOND;// failed posts gets 5 second penalty
             }
 
 


### PR DESCRIPTION
Currently there is a bug that if one of the endpoint posts fails, the balancer will not update the "response time" to a large value, which ends up all posting to that endpoint because it becomes zero.

This can be prevented by setting the response time to a large value before doing anything.